### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,3 +148,8 @@ If you ever suspect you're on an old version, run `npm cache clean --force` to c
 Proudly made for Boilermakers by [Rohan Muppa](https://github.com/rohanmuppa) 🚂
 
 [Report a bug](https://github.com/rohanmuppa/brightspace-mcp-server/issues) · AGPL-3.0 · Copyright 2026 Rohan Muppa
+
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/rohanmuppa-brightspace-mcp-server).
+


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/rohanmuppa-brightspace-mcp-server).